### PR TITLE
Update .profile to export XDG base dirs

### DIFF
--- a/.profile
+++ b/.profile
@@ -14,6 +14,9 @@ export BROWSER="brave"
 export READER="zathura"
 export STATUSBAR="${LARBSWM}blocks"
 
+# Export XDG environmental variables from '~/.config/user-dirs.dirs'
+eval "$(sed 's/^[^#].*/export &/g;t;d' ~/.config/user-dirs.dirs)"
+
 # ~/ Clean-up:
 #export XAUTHORITY="$XDG_RUNTIME_DIR/Xauthority" # This line will break some DMs.
 export NOTMUCH_CONFIG="$HOME/.config/notmuch-config"


### PR DESCRIPTION
Not every program will read them from ~/.config/user-dirs.dirs so might as well export them yourself... Also can now use them elsewhere.